### PR TITLE
Do not import ray if not used

### DIFF
--- a/backend/deepchecks_monitoring/api/v1/check.py
+++ b/backend/deepchecks_monitoring/api/v1/check.py
@@ -7,6 +7,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Deepchecks.  If not, see <http://www.gnu.org/licenses/>.
 # ----------------------------------------------------------------------------
+# pylint: disable=import-outside-toplevel
 """V1 API of the check."""
 import typing as t
 

--- a/backend/deepchecks_monitoring/api/v1/check.py
+++ b/backend/deepchecks_monitoring/api/v1/check.py
@@ -37,7 +37,6 @@ from deepchecks_monitoring.logic.check_logic import (CheckNotebookSchema, CheckR
 from deepchecks_monitoring.logic.model_logic import (get_model_versions_for_time_range,
                                                      get_results_for_model_versions_per_window,
                                                      get_top_features_or_from_conf)
-from deepchecks_monitoring.logic.parallel_check_executor import execute_check_per_window
 from deepchecks_monitoring.logic.statistics import bins_for_feature
 from deepchecks_monitoring.monitoring_utils import (CheckIdentifier, DataFilter, DataFilterList, ExtendedAsyncSession,
                                                     ModelIdentifier, MonitorCheckConf, NameIdResponse, OperatorsEnum,
@@ -399,6 +398,7 @@ async def run_standalone_check_per_window_in_range(
         Check run result.
     """
     if pool := resources_provider.parallel_check_executors_pool:
+        from deepchecks_monitoring.logic.parallel_check_executor import execute_check_per_window
         return await execute_check_per_window(
             actor_pool=pool,
             session=session,

--- a/backend/deepchecks_monitoring/app.py
+++ b/backend/deepchecks_monitoring/app.py
@@ -14,7 +14,6 @@ import typing as t
 
 import deepchecks
 import dotenv
-import ray
 from fastapi import FastAPI, HTTPException, Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
@@ -110,11 +109,12 @@ def create_application(
 
     if settings.init_local_ray_instance is not None:
         try:
+            import ray
             ray.init(address="auto")
         except ConnectionError:
             logger.info("Local ray instance is not instantiated")
         else:
-            logger.info("Conected to local ray instance")
+            logger.info("Connected to local ray instance")
 
     @app.exception_handler(BaseHTTPException)
     async def base_http_exceptions_handler(

--- a/backend/deepchecks_monitoring/app.py
+++ b/backend/deepchecks_monitoring/app.py
@@ -7,6 +7,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Deepchecks.  If not, see <http://www.gnu.org/licenses/>.
 # ----------------------------------------------------------------------------
+# pylint: disable=import-outside-toplevel
 """Module defining the app."""
 import asyncio
 import logging
@@ -176,7 +177,7 @@ def create_application(
 
     # Add stuff available only in the enterprise version
     try:
-        from deepchecks_monitoring import ee  # pylint: disable=import-outside-toplevel
+        from deepchecks_monitoring import ee
     except ImportError:
         pass
     else:
@@ -187,7 +188,7 @@ def create_application(
 
         # Configure telemetry
         if settings.sentry_dsn:
-            import sentry_sdk  # pylint: disable=import-outside-toplevel
+            import sentry_sdk
 
             sentry_sdk.init(
                 dsn=settings.sentry_dsn,
@@ -200,7 +201,7 @@ def create_application(
             ee.utils.telemetry.collect_telemetry(DataIngestionBackend)
 
         if settings.stripe_secret_api_key:
-            import stripe  # pylint: disable=import-outside-toplevel
+            import stripe
             stripe.api_key = settings.stripe_secret_api_key
 
         if settings.debug_mode:

--- a/backend/deepchecks_monitoring/resources.py
+++ b/backend/deepchecks_monitoring/resources.py
@@ -7,7 +7,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Deepchecks.  If not, see <http://www.gnu.org/licenses/>.
 # ----------------------------------------------------------------------------
-#  pylint: disable=unnecessary-ellipsis
+#  pylint: disable=unnecessary-ellipsis,import-outside-toplevel
 """Module with resources instatiation logic."""
 import logging
 import typing as t

--- a/backend/deepchecks_monitoring/resources.py
+++ b/backend/deepchecks_monitoring/resources.py
@@ -7,8 +7,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with Deepchecks.  If not, see <http://www.gnu.org/licenses/>.
 # ----------------------------------------------------------------------------
-#  pylint: disable=unnecessary-ellipsis,import-outside-toplevel
-"""Module with resources instatiation logic."""
+# pylint: disable=unnecessary-ellipsis
+"""Module with resources instantiation logic."""
 import logging
 import typing as t
 from contextlib import asynccontextmanager, contextmanager
@@ -343,10 +343,11 @@ class ResourcesProvider(BaseResourcesProvider):
         return self._email_sender
 
     @property
-    def parallel_check_executors_pool(self) -> "ActorPool | None":
+    def parallel_check_executors_pool(self):
         """Return parallel check executors actors."""
-        import ray
-        from ray.util.actor_pool import ActorPool
+        # pylint: disable=import-outside-toplevel
+        import ray  # noqa
+        from ray.util.actor_pool import ActorPool  # noqa
 
         if not ray.is_initialized():
             logging.getLogger("server").info("Ray is not initialized")
@@ -355,7 +356,6 @@ class ResourcesProvider(BaseResourcesProvider):
         if pool := getattr(self, "_parallel_check_executors", None):
             return pool
 
-        # pylint: disable=import-outside-toplevel
         from deepchecks_monitoring.logic.parallel_check_executor import CheckPerWindowExecutor
         database_uri = str(self.database_settings.database_uri)
 
@@ -371,7 +371,8 @@ class ResourcesProvider(BaseResourcesProvider):
     def shutdown_parallel_check_executors_pool(self):
         """Shutdown parallel check executors actors."""
         self._parallel_check_executors = None
-        import ray
+        # pylint: disable=import-outside-toplevel
+        import ray  # noqa
         ray.shutdown()
 
     def ensure_kafka_topic(self, topic_name, num_partitions=1) -> bool:

--- a/backend/deepchecks_monitoring/resources.py
+++ b/backend/deepchecks_monitoring/resources.py
@@ -14,13 +14,11 @@ import typing as t
 from contextlib import asynccontextmanager, contextmanager
 
 import httpx
-import ray
 from aiokafka import AIOKafkaProducer
 from authlib.integrations.starlette_client import OAuth
 from kafka import KafkaAdminClient
 from kafka.admin import NewTopic
 from kafka.errors import TopicAlreadyExistsError
-from ray.util.actor_pool import ActorPool
 from redis.client import Redis
 from redis.cluster import RedisCluster
 from redis.exceptions import RedisClusterException
@@ -347,6 +345,9 @@ class ResourcesProvider(BaseResourcesProvider):
     @property
     def parallel_check_executors_pool(self) -> "ActorPool | None":
         """Return parallel check executors actors."""
+        import ray
+        from ray.util.actor_pool import ActorPool
+
         if not ray.is_initialized():
             logging.getLogger("server").info("Ray is not initialized")
             return
@@ -370,6 +371,7 @@ class ResourcesProvider(BaseResourcesProvider):
     def shutdown_parallel_check_executors_pool(self):
         """Shutdown parallel check executors actors."""
         self._parallel_check_executors = None
+        import ray
         ray.shutdown()
 
     def ensure_kafka_topic(self, topic_name, num_partitions=1) -> bool:


### PR DESCRIPTION
Sadly ray isn't supported yet on macos + python 3.11
Moved all the imports inside functions to not import ray if not needed