### PR TITLE
Preventing long-running task from running twice

### DIFF
--- a/backend/deepchecks_monitoring/bgtasks/alert_task.py
+++ b/backend/deepchecks_monitoring/bgtasks/alert_task.py
@@ -49,7 +49,7 @@ class AlertsTask(BackgroundWorker):
     def delay_seconds(cls) -> int:
         return 0
 
-    async def run(self, task: Task, session: AsyncSession, resources_provider: ResourcesProvider):
+    async def run(self, task: Task, session: AsyncSession, resources_provider: ResourcesProvider, lock):
         organization_id = task.params["organization_id"]
         monitor_id = task.params["monitor_id"]
         timestamp = task.params["timestamp"]

--- a/backend/deepchecks_monitoring/bgtasks/delete_db_table_task.py
+++ b/backend/deepchecks_monitoring/bgtasks/delete_db_table_task.py
@@ -35,7 +35,7 @@ class DeleteDbTableTask(BackgroundWorker):
     def delay_seconds(cls) -> int:
         return 0
 
-    async def run(self, task: 'Task', session: AsyncSession, resources_provider):
+    async def run(self, task: 'Task', session: AsyncSession, resources_provider, lock):
         for table in task.params['full_table_paths']:
             await session.execute(text(f'DROP TABLE IF EXISTS {table}'))
         # Deleting the task

--- a/backend/deepchecks_monitoring/bgtasks/model_data_ingestion_alerter.py
+++ b/backend/deepchecks_monitoring/bgtasks/model_data_ingestion_alerter.py
@@ -46,7 +46,8 @@ class ModelDataIngestionAlerter(BackgroundWorker):
 
     async def run(self, task: "Task",
                   session: AsyncSession,  # pylint: disable=unused-argument
-                  resources_provider: ResourcesProvider):
+                  resources_provider: ResourcesProvider,
+                  lock):
         alert_rule_id = task.params["alert_rule_id"]
         org_id = task.params["organization_id"]
         end_time = task.params["end_time"]

--- a/backend/deepchecks_monitoring/bgtasks/model_version_cache_invalidation.py
+++ b/backend/deepchecks_monitoring/bgtasks/model_version_cache_invalidation.py
@@ -33,7 +33,7 @@ class ModelVersionCacheInvalidation(BackgroundWorker):
     def delay_seconds(cls) -> int:
         return DELAY
 
-    async def run(self, task: 'Task', session: AsyncSession, resources_provider):
+    async def run(self, task: 'Task', session: AsyncSession, resources_provider, lock):
         # Delete task
         await session.execute(delete(Task).where(Task.id == task.id))
 

--- a/backend/deepchecks_monitoring/bgtasks/model_version_offset_update.py
+++ b/backend/deepchecks_monitoring/bgtasks/model_version_offset_update.py
@@ -51,7 +51,7 @@ class ModelVersionOffsetUpdate(BackgroundWorker):
     def delay_seconds(cls) -> int:
         return DELAY
 
-    async def run(self, task: 'Task', session: AsyncSession, resources_provider):
+    async def run(self, task: 'Task', session: AsyncSession, resources_provider, lock):
         # Backward compatibility, remove in next release and replace with:
         # entity_id = task.params['id']
         # entity = task.params['entity']

--- a/backend/deepchecks_monitoring/bgtasks/model_version_topic_delete.py
+++ b/backend/deepchecks_monitoring/bgtasks/model_version_topic_delete.py
@@ -53,7 +53,7 @@ class ModelVersionTopicDeletionWorker(BackgroundWorker):
     def delay_seconds(cls) -> int:
         return DELAY
 
-    async def run(self, task: 'Task', session: AsyncSession, resources_provider: ResourcesProvider):
+    async def run(self, task: 'Task', session: AsyncSession, resources_provider: ResourcesProvider, lock):
         # Backward compatibility, remove in next release and replace with:
         # model_version_id = task.params['id']
         # entity = task.params['entity']

--- a/backend/deepchecks_monitoring/bgtasks/tasks_queuer.py
+++ b/backend/deepchecks_monitoring/bgtasks/tasks_queuer.py
@@ -17,9 +17,9 @@ from time import perf_counter
 
 import anyio
 import pendulum as pdl
-from redis.asyncio import Redis, RedisCluster
 import redis.exceptions as redis_exceptions
 import uvloop
+from redis.asyncio import Redis, RedisCluster
 from sqlalchemy import case, func, update
 from sqlalchemy.cimmutabledict import immutabledict
 
@@ -135,6 +135,7 @@ else:
     class WorkerSettings(BaseWorkerSettings):
         """Set of worker settings."""
         pass
+
 
 async def init_async_redis(redis_uri):
     """Initialize redis connection."""

--- a/backend/deepchecks_monitoring/bgtasks/tasks_queuer.py
+++ b/backend/deepchecks_monitoring/bgtasks/tasks_queuer.py
@@ -18,7 +18,7 @@ from time import perf_counter
 import anyio
 import pendulum as pdl
 from redis.asyncio import Redis, RedisCluster
-from redis.exceptions import RedisClusterException, ConnectionError
+import redis.exceptions as redis_exceptions
 import uvloop
 from sqlalchemy import case, func, update
 from sqlalchemy.cimmutabledict import immutabledict
@@ -105,7 +105,7 @@ class TasksQueuer:
                 # Push to sorted set. if task id is already in set then do nothing.
                 pushed_count = await self.redis.zadd(GLOBAL_TASK_QUEUE, task_ids, nx=True)
                 return pushed_count
-            except ConnectionError:
+            except redis_exceptions.ConnectionError:
                 # If redis failed, does not commit the update to the db
                 await session.rollback()
         return 0
@@ -142,7 +142,7 @@ async def init_async_redis(redis_uri):
         redis = RedisCluster.from_url(redis_uri)
         await redis.ping()
         return redis
-    except RedisClusterException:
+    except redis_exceptions.RedisClusterException:
         return Redis.from_url(redis_uri)
 
 

--- a/backend/deepchecks_monitoring/bgtasks/tasks_runner.py
+++ b/backend/deepchecks_monitoring/bgtasks/tasks_runner.py
@@ -9,7 +9,6 @@
 # ----------------------------------------------------------------------------
 #
 """Contains alert scheduling logic."""
-import inspect
 import logging.handlers
 import typing as t
 

--- a/backend/deepchecks_monitoring/bgtasks/tasks_runner.py
+++ b/backend/deepchecks_monitoring/bgtasks/tasks_runner.py
@@ -17,7 +17,7 @@ import anyio
 import pendulum as pdl
 import uvloop
 from redis.asyncio import Redis, RedisCluster
-from redis.exceptions import RedisClusterException, LockNotOwnedError
+from redis.exceptions import LockNotOwnedError, RedisClusterException
 from sqlalchemy import select
 
 from deepchecks_monitoring.bgtasks.alert_task import AlertsTask

--- a/backend/deepchecks_monitoring/ee/utils/telemetry.py
+++ b/backend/deepchecks_monitoring/ee/utils/telemetry.py
@@ -294,7 +294,7 @@ class TaskRunerInstrumentor:
         """Instrument the task runner functions we want to monitor."""
 
         @wraps(self.original_run_task)
-        async def _run_task(runner: "TaskRunner", task, session, queued_time):
+        async def _run_task(runner: "TaskRunner", task, session, queued_time, lock):
             redis_uri = runner.resource_provider.redis_settings.redis_uri
             database_uri = runner.resource_provider.database_settings.database_uri
             kafka_settings = runner.resource_provider.kafka_settings
@@ -327,7 +327,7 @@ class TaskRunerInstrumentor:
 
                     try:
                         start = perf_counter()
-                        result = await self.original_run_task(runner, task, session, queued_time)
+                        result = await self.original_run_task(runner, task, session, queued_time, lock)
                         span.set_data("task.execution-duration", perf_counter() - start)
                         span.set_status(SpanStatus.OK)
                     except Exception as error:

--- a/backend/deepchecks_monitoring/logic/keys.py
+++ b/backend/deepchecks_monitoring/logic/keys.py
@@ -20,6 +20,7 @@ DATA_TOPIC_PREFIXES = {
 reverse_data_topic_prefixes = {v: k for k, v in DATA_TOPIC_PREFIXES.items()}
 GLOBAL_TASK_QUEUE = "task_queue"
 INVALIDATION_SET_PREFIX = "invalidation"
+TASK_RUNNER_LOCK = "task_runner_lock:{}"
 
 
 def get_data_topic_name(organization_id, entity_id, entity: t.Literal["model", "model-version"]) -> str:

--- a/backend/deepchecks_monitoring/public_models/task.py
+++ b/backend/deepchecks_monitoring/public_models/task.py
@@ -12,6 +12,7 @@ import abc
 import typing as t
 from datetime import datetime
 
+from redis.asyncio.lock import Lock
 import sqlalchemy as sa
 from sqlalchemy import Integer, func
 from sqlalchemy.dialects.postgresql import JSONB, TIMESTAMP
@@ -41,7 +42,7 @@ class BackgroundWorker(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def run(self, task: 'Task', session: AsyncSession, resources_provider):
+    async def run(self, task: 'Task', session: AsyncSession, resources_provider, lock: Lock):
         """Main logic of the worker."""
         pass
 

--- a/backend/deepchecks_monitoring/public_models/task.py
+++ b/backend/deepchecks_monitoring/public_models/task.py
@@ -12,8 +12,8 @@ import abc
 import typing as t
 from datetime import datetime
 
-from redis.asyncio.lock import Lock
 import sqlalchemy as sa
+from redis.asyncio.lock import Lock
 from sqlalchemy import Integer, func
 from sqlalchemy.dialects.postgresql import JSONB, TIMESTAMP
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/backend/dev-requirements.txt
+++ b/backend/dev-requirements.txt
@@ -21,4 +21,4 @@ tox==3.25.1
 faker
 pyOpenSSL
 aiosmtpd
-fakeredis==2.9.2
+fakeredis[lua]==2.9.2

--- a/backend/tests/logic/test_cache_functions.py
+++ b/backend/tests/logic/test_cache_functions.py
@@ -63,7 +63,7 @@ async def test_delete_monitor_cache_by_timestamp(resources_provider):
     async with resources_provider.async_session_factory() as session:
         task_id = await insert_model_version_cache_invalidation_task(1, 1, session=session)
         task = await session.scalar(select(Task).where(Task.id == task_id))
-        await ModelVersionCacheInvalidation().run(task, session, resources_provider)
+        await ModelVersionCacheInvalidation().run(task, session, resources_provider, lock=None)
 
     # Assert - 2 monitors and 3 timestamps
     assert len(cache_funcs.redis.keys()) == 400 - 2 * 3

--- a/backend/tests/unittests/test_model_data_ingestion_alerts.py
+++ b/backend/tests/unittests/test_model_data_ingestion_alerts.py
@@ -102,7 +102,7 @@ async def test_data_ingestion_scheduling(
 
     worker = ModelDataIngestionAlerter()
     for task in tasks:
-        await worker.run(task, async_session, resources_provider)
+        await worker.run(task, async_session, resources_provider, lock=None)
 
     resp = client.get(
         f"api/v1/data-ingestion-alert-rules/{alert_rules[0]['id']}/alerts")

--- a/backend/tests/unittests/test_monitor_alert_rules_executor.py
+++ b/backend/tests/unittests/test_monitor_alert_rules_executor.py
@@ -17,8 +17,8 @@ import pendulum as pdl
 import pytest
 import sqlalchemy as sa
 from deepchecks.tabular.checks import SingleDatasetPerformance
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from fakeredis.aioredis import FakeRedis
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from deepchecks_monitoring.bgtasks.alert_task import AlertsTask, execute_monitor
 from deepchecks_monitoring.bgtasks.scheduler import AlertsScheduler

--- a/backend/tests/unittests/test_queuer_runner.py
+++ b/backend/tests/unittests/test_queuer_runner.py
@@ -29,7 +29,7 @@ class Worker(BackgroundWorker):
     def delay_seconds(cls) -> int:
         return 0
 
-    async def run(self, task: Task, session: AsyncSession, resources_provider):
+    async def run(self, task: Task, session: AsyncSession, resources_provider, lock):
         await session.execute(sa.update(Task).where(Task.id == task.id).values({'params': {'run': True}}))
         await session.commit()
 

--- a/backend/tests/unittests/test_queuer_runner.py
+++ b/backend/tests/unittests/test_queuer_runner.py
@@ -13,6 +13,7 @@ import logging
 import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
+from fakeredis.aioredis import FakeRedis
 
 from deepchecks_monitoring.bgtasks.tasks_queuer import TasksQueuer
 from deepchecks_monitoring.bgtasks.tasks_runner import TaskRunner
@@ -39,8 +40,9 @@ logger = logging.Logger('test')
 @pytest.mark.asyncio
 async def test_task_queue(resources_provider, async_session):
     workers = [Worker()]
-    queuer = TasksQueuer(resources_provider, workers, logger, 1)
-    runner = TaskRunner(resources_provider, resources_provider.redis_client, workers, logger)
+    redis = FakeRedis()
+    queuer = TasksQueuer(resources_provider, redis, workers, logger, 1)
+    runner = TaskRunner(resources_provider, redis, workers, logger)
 
     await async_session.execute(sa.insert(Task).values({'name': 'test', 'bg_worker_task': 'test'}))
     await async_session.commit()

--- a/backend/tests/unittests/test_queuer_runner.py
+++ b/backend/tests/unittests/test_queuer_runner.py
@@ -12,8 +12,8 @@ import logging
 
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.ext.asyncio import AsyncSession
 from fakeredis.aioredis import FakeRedis
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from deepchecks_monitoring.bgtasks.tasks_queuer import TasksQueuer
 from deepchecks_monitoring.bgtasks.tasks_runner import TaskRunner


### PR DESCRIPTION
1. Task queuer also using async redis now
2. Using distributed lock per task id allows each worker to control his lock. This allows us to create long-running tasks without risking of same task running twice in parallel