### PR TITLE
Change regex to reject double "@"

### DIFF
--- a/frontend/src/helpers/utils/validateEmail.ts
+++ b/frontend/src/helpers/utils/validateEmail.ts
@@ -1,2 +1,2 @@
 // taken from: https://stackoverflow.com/questions/46155/how-can-i-validate-an-email-address-in-javascript
-export const validateEmail = (email: string) => /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(email)
+export const validateEmail = (email: string) => /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(email)

--- a/frontend/src/helpers/utils/validateEmail.ts
+++ b/frontend/src/helpers/utils/validateEmail.ts
@@ -1,1 +1,2 @@
-export const validateEmail = (email: string) => /\S+@\S+\.\S+/.test(email);
+// taken from: https://stackoverflow.com/questions/46155/how-can-i-validate-an-email-address-in-javascript
+export const validateEmail = (email: string) => /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(email)


### PR DESCRIPTION
Linear Bug: https://linear.app/deepchecks/issue/MON-2328/invite-user-change-invalid-user-mail-error-message

On server side we validate email using paydantic, on client side also validate the email for better user experience using regex.
I've changed client side to support more robust validation using common stackoverflow answer.

Tested the code locally.
